### PR TITLE
ログイン中のユーザーがsignin画面に飛んだ時にとりあえずhome画面に飛ぶようにする #83

### DIFF
--- a/pages/form.tsx
+++ b/pages/form.tsx
@@ -14,7 +14,7 @@ import Router from 'next/router';
 type Detail = { title: string; tags: string; text: string };
 export default function Form() {
   const [cookies] = useCookies(['token']);
-
+  console.log(cookies);
   React.useEffect(() => {
     !Object.keys(cookies).length && Router.push('/signin');
   }, [cookies]);

--- a/pages/form.tsx
+++ b/pages/form.tsx
@@ -14,7 +14,6 @@ import Router from 'next/router';
 type Detail = { title: string; tags: string; text: string };
 export default function Form() {
   const [cookies] = useCookies(['token']);
-  console.log(cookies);
   React.useEffect(() => {
     !Object.keys(cookies).length && Router.push('/signin');
   }, [cookies]);

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -53,7 +53,10 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export default function SignIn() {
-  const [, setCookie] = useCookies(['token']);
+  const [cookies, setCookie] = useCookies(['token']);
+  useEffect(() => {
+    Object.keys(cookies).length && Router.push('/');
+  }, [cookies]);
   const [sign_in] = useMutation(SIGN_IN, {
     update: (_proxy, response) => {
       if (response.data.sign_in) {


### PR DESCRIPTION
## Issue

Closes #83 

## 今回の PR で行ったこと

-signin中のユーザーがsignin画面に遷移できないようにする

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

-サインイン/サインアウト時の共同を確認

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-signin.tsx

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
