### PR TITLE
マイページボタンの修正#111

### DIFF
--- a/components/HeaderItem.tsx
+++ b/components/HeaderItem.tsx
@@ -71,9 +71,6 @@ const HeaderItem = () => {
             投稿
             <ArrowDropDownIcon />
           </IconButton>
-          <Link href="/users/[id]" as={`/users/${userId}`}>
-            <IconButton className={classes.button}>マイページ</IconButton>
-          </Link>
           <IconButton
             aria-label="account of current user"
             aria-controls="menu-appbar"
@@ -82,19 +79,21 @@ const HeaderItem = () => {
             onClick={handleClick}
           >
             <AccountCircle className={classes.icon} />
-            </IconButton>
-            <Menu
-              id="simple-menu"
-              anchorEl={anchorEl}
-              // keepMounted
-              open={Boolean(anchorEl)}
-              onClose={handleClose}
-            >
+          </IconButton>
+          <Menu
+            id="simple-menu"
+            anchorEl={anchorEl}
+            // keepMounted
+            open={Boolean(anchorEl)}
+            onClose={handleClose}
+          >
+            <Link href="/users/[id]" as={`/users/${userId}`}>
               <MenuItem onClick={() => console.log(Boolean(anchorEl))}>
                 My account
               </MenuItem>
-              <MenuItem onClick={handleClose}>Logout</MenuItem>
-            </Menu>
+            </Link>
+            <MenuItem onClick={handleClose}>Logout</MenuItem>
+          </Menu>
         </>
       )}
     </>


### PR DESCRIPTION
## Issue

Closes #111

## 今回の PR で行ったこと

-現在ユーザーのアイコンの横にマイページというボタンがあり、それを押したときにアカウント画面に飛んでいるが、アイコンを押してそこに出てくるマイアカウントボタンを押したときにアカウント画面に飛ぶようにする。また、マイページというボタンは消す。

## 動作確認(どのような動作確認を行ったのか？ 結果はどうか？)

-

## 影響範囲(行った作業によってどこまで影響が及ぶようになるか)

-components/HeaderItem.tsx

## 実装するにあたって参考にした URL

-

## 確認して欲しいこと

-

## 懸念点

-
